### PR TITLE
docs(errors): document error code capture timing in setErrorCodes

### DIFF
--- a/packages/errors/src/lib/codes.ts
+++ b/packages/errors/src/lib/codes.ts
@@ -21,6 +21,12 @@ export const errorCodes: ErrorCodes = {
  * Updates the existing errorCodes object with new values.
  * Only provided properties in the Partial<ErrorCodes> object are updated.
  *
+ * This mutates a process-global singleton, so call it once during application
+ * startup, before any errors are constructed or thrown. The built-in error
+ * subclasses (ValidationError, UnauthenticatedUserError, ServerError) capture
+ * their status code at construction time, so reconfiguring the codes afterwards
+ * does not affect errors that already exist — only ones created later.
+ *
  * @param obj - Partial object containing new error codes.
  */
 export const setErrorCodes = (obj: Partial<ErrorCodes>) => {

--- a/packages/errors/src/lib/errors.spec.ts
+++ b/packages/errors/src/lib/errors.spec.ts
@@ -133,3 +133,30 @@ describe('Testing with change Codes', () => {
         expect(serverError.getCode()).toBe(200)
     })
 })
+
+describe('Error code capture timing', () => {
+    beforeAll(() => {
+        setErrorCodes({ VALIDATION_ERROR_CODE: 400 })
+    })
+
+    afterAll(() => {
+        setErrorCodes({
+            VALIDATION_ERROR_CODE: 400,
+            UNAUTHENTICATED_USER_ERROR_CODE: 401,
+            SERVER_ERROR_CODE: 500
+        })
+    })
+
+    it('captures the error code at construction time, not at read time', () => {
+        const error = new ValidationError('Validation error', { errRes: { errors: {} } })
+        expect(error.getCode()).toBe(400)
+
+        // Reconfiguring codes after construction must not affect an existing error.
+        setErrorCodes({ VALIDATION_ERROR_CODE: 422 })
+        expect(error.getCode()).toBe(400)
+
+        // Only errors constructed after the change pick up the new code.
+        const newError = new ValidationError('Validation error', { errRes: { errors: {} } })
+        expect(newError.getCode()).toBe(422)
+    })
+})


### PR DESCRIPTION
Built-in subclasses capture their status code at construction time, while setErrorCodes mutates a process-global. Document that it must be called once at startup before errors are constructed, and pin the capture-at-construction behavior with a test so it stays intentional.